### PR TITLE
🐛 Fix nginx container: CSP, MIME types, homepage-link

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -77,7 +77,7 @@ jobs:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: pm-5sj
           deployment-name: pr${{ github.event.pull_request.number }}
-          component: frontend
+          component: proef
           image: ${{ needs.build.outputs.image }}
           comment-on-pr: true
           qr-code: true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -68,6 +68,6 @@ jobs:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: pm-5sj
           deployment-name: poc
-          component: frontend
+          component: proef
           image: ${{ needs.build.outputs.image }}
           wait-for-ready: true

--- a/_includes/header-overheid.njk
+++ b/_includes/header-overheid.njk
@@ -1,6 +1,6 @@
 <header>
 	<figure class="logo">
-		<a href="/poc-moza/">
+		<a href="/moza/">
 			<img src="{{ '/assets/images/beeldmerk-rijksoverheid.svg' | url }}" alt="Naar de homepage van MijnOverheid Zakelijk">
 		</a>
 	</figure>

--- a/container/default.conf
+++ b/container/default.conf
@@ -12,16 +12,15 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
-    add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'none';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'none';" always;
     add_header Strict-Transport-Security "max-age=31536000" always;
+
+    location = /favicon.ico {
+        alias /usr/share/nginx/html/assets/favicon/favicon.ico;
+    }
 
     location /.well-known/security.txt {
         return 302 https://www.ncsc.nl/.well-known/security.txt;
-    }
-
-    location ~* \.(css|js)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
     }
 
     location / {

--- a/container/nginx.conf
+++ b/container/nginx.conf
@@ -15,6 +15,9 @@ http {
     scgi_temp_path /tmp/scgi_temp;
 
     include /etc/nginx/mime.types;
+    types {
+        font/ttf ttf;
+    }
     default_type application/octet-stream;
 
     access_log off;


### PR DESCRIPTION
## Summary
- **CSP fix**: `script-src` en `style-src` met `'self' 'unsafe-inline'` toegevoegd — inline scripts en styles werden geblokkeerd
- **CSS/JS cache-blok verwijderd** — loste nginx `add_header` inheritance-bug op (security headers ontbraken op CSS/JS) en verwijdert onnodige 1-jaar cache voor een PoC
- **Font MIME type**: `font/ttf` toegevoegd voor `.ttf` bestanden (werden geserveerd als `application/octet-stream`)
- **Homepage-link**: `/poc-moza/` → `/moza/` in header template (oude pad bestond niet in container)
- **ZAD component**: hernoemd van `frontend` naar `proef`
- **Favicon**: alias zodat `/favicon.ico` naar `/assets/favicon/favicon.ico` verwijst

## Test plan
- [x] Open de preview-deployment — geen console errors
- [x] Klik op het rijksoverheid-logo — linkt naar `/moza/`
- [x] Navigatie-toggle en subnav-preview werken (inline scripts niet meer geblokkeerd)
- [x] Fonts laden correct (geen fallback-font zichtbaar)