### PR TITLE
💄 Wacht-indicator bij vervolg-page-loads en gesprekwissels

### DIFF
--- a/assets/javascript/digitale-assistent.js
+++ b/assets/javascript/digitale-assistent.js
@@ -186,6 +186,33 @@
 		schrijf(OPSLAG_HISTORIE, chatHistory);
 	}
 
+	// De assistent "denkt" kort voordat die iets nieuws zegt: dezelfde
+	// wait-indicator als tijdens de onboarding, zodat een nieuw gesprek, een
+	// wissel of een volgende page-load niet abrupt met kant-en-klare tekst
+	// begint. Het token laat een snel opvolgende wachtbeurt de vorige afbreken.
+	// Bij het laden van de pagina langer wachten dan bij een wissel: de eerste
+	// verf komt pas na het opbouwen van de pagina, dus een korte wachttijd is dan
+	// al voorbij voordat de indicator te zien is.
+	var WACHT_KORT = 700;
+	var WACHT_PAGINALAAD = 1600;
+	var wachtToken = 0;
+	function naWachten(callback, duur) {
+		var eigenToken = ++wachtToken;
+		showThinking("");
+		// Pas na de eerstvolgende verf de klok starten, anders telt de tijd die de
+		// browser nog aan de pagina besteedt mee als wachttijd.
+		requestAnimationFrame(function () {
+			requestAnimationFrame(function () {
+				if (eigenToken !== wachtToken) return;
+				setTimeout(function () {
+					if (eigenToken !== wachtToken) return;
+					hideThinking();
+					callback();
+				}, duur || WACHT_KORT);
+			});
+		});
+	}
+
 	function nieuwGesprek() {
 		var combo = getComboKey();
 		delete sessions[combo];
@@ -196,9 +223,12 @@
 		messages.scrollTop = 0;
 		input.value = "";
 		verwijderSuggestieIntro();
-		showSuggestionPrompt(true);
+		heeftGesprek = false;
 		disableNieuwKnop();
 		input.focus();
+		naWachten(function () {
+			showSuggestionPrompt(true);
+		});
 	}
 
 	// Leesbare labels per backend-sleutel, gecombineerd in ALL_LABELS voor friendlyTool.
@@ -818,18 +848,30 @@
 	}
 
 	var nieuwKnop = document.getElementById("chat-nieuw");
-	if (nieuwKnop) nieuwKnop.addEventListener("click", nieuwGesprek);
+	// Er valt pas iets te wissen zodra de gebruiker een bericht heeft gestuurd.
+	// Tijdens het streamen van een antwoord blijft de knop bereikbaar voor
+	// toetsenbord en screenreader (aria-disabled, geen disabled), maar doet die
+	// niets: anders wist een klik de chat onder het lopende antwoord vandaan.
+	var heeftGesprek = false;
+	if (nieuwKnop)
+		nieuwKnop.addEventListener("click", function () {
+			if (nieuwKnop.getAttribute("aria-disabled") === "true") return;
+			nieuwGesprek();
+		});
 
 	function enableNieuwKnop() {
-		if (nieuwKnop) nieuwKnop.removeAttribute("disabled");
+		if (nieuwKnop) nieuwKnop.removeAttribute("aria-disabled");
 	}
 
 	function disableNieuwKnop() {
-		if (nieuwKnop) nieuwKnop.setAttribute("disabled", "");
+		if (nieuwKnop) nieuwKnop.setAttribute("aria-disabled", "true");
 	}
 
-	// Zorg dat de knop altijd disabled start
-	disableNieuwKnop();
+	// Uitgeschakeld starten, tenzij er een gesprek is teruggezet uit deze sessie:
+	// dan valt er wél iets te wissen.
+	heeftGesprek = Boolean(chatHistory[previousCombo]);
+	if (heeftGesprek) enableNieuwKnop();
+	else disableNieuwKnop();
 
 	function handleSwitch() {
 		if (submitting) return;
@@ -841,13 +883,27 @@
 		previousCombo = next;
 		bewaarHistorie(prev);
 
+		// Per combinatie een eigen gesprek: de knop volgt de combinatie waar we
+		// naartoe wisselen, niet die we verlaten.
+		heeftGesprek = Boolean(chatHistory[next]);
+		if (heeftGesprek) enableNieuwKnop();
+		else disableNieuwKnop();
+
+		// Bestaand gesprek komt meteen terug: er is niets nieuws van de assistent.
+		// Een leeg gesprek begint wél met de wait-indicator, net als bij een
+		// nieuw gesprek en een volgende page-load.
 		if (chatHistory[next]) {
 			messages.innerHTML = chatHistory[next];
-		} else {
-			messages.innerHTML = initialMessages;
+			messages.scrollTop = messages.scrollHeight;
+			updateStatusDisplay();
+			return;
 		}
-		messages.scrollTop = messages.scrollHeight;
+		messages.innerHTML = "";
 		updateStatusDisplay();
+		naWachten(function () {
+			messages.innerHTML = initialMessages;
+			messages.scrollTop = messages.scrollHeight;
+		});
 	}
 
 	window.addEventListener("setting-changed", function (e) {
@@ -1044,7 +1100,8 @@
 		pendingOpgaven = null;
 
 		submitting = true;
-		enableNieuwKnop();
+		heeftGesprek = true;
+		disableNieuwKnop();
 		addMessage(message, "user");
 		input.value = "";
 		input.style.blockSize = "auto";
@@ -1063,6 +1120,7 @@
 			} finally {
 				setLoading(false);
 				submitting = false;
+				if (heeftGesprek) enableNieuwKnop();
 				if (getComboKey() === comboKey) bewaarHistorie(comboKey);
 			}
 			return;
@@ -1221,6 +1279,7 @@
 			clearTimeout(connectTimer);
 			if (idleTimer) clearTimeout(idleTimer);
 			submitting = false;
+			if (heeftGesprek) enableNieuwKnop();
 			// Vastleggen na afloop van de beurt, niet per bericht: bij een
 			// afgebroken stream staat de laatste stand er dan alsnog in.
 			if (getComboKey() === comboKey) bewaarHistorie(comboKey);
@@ -1277,11 +1336,13 @@
 	// zodat het gesprek zonder extra klik begint.
 	var startvraag = new URLSearchParams(location.search).get("vraag");
 	if (heeftOnboardingGezien()) {
-		showSuggestionPrompt(true);
-		if (startvraag && startvraag.trim()) {
-			input.value = startvraag.trim();
-			form.requestSubmit();
-		}
+		naWachten(function () {
+			showSuggestionPrompt(true);
+			if (startvraag && startvraag.trim()) {
+				input.value = startvraag.trim();
+				form.requestSubmit();
+			}
+		}, WACHT_PAGINALAAD);
 	} else if (startvraag && startvraag.trim()) {
 		// Eerste bezoek: toon onboarding inclusief intro, zonder replay-knop
 		showOnboardingMessages().then(function() {

--- a/moza/digitale-assistent.html
+++ b/moza/digitale-assistent.html
@@ -33,7 +33,7 @@ title: "MijnOverheid Zakelijk: Digitale assistent"
 			<textarea id="chat-input" placeholder="Waarmee kan ik u helpen?" required></textarea>
 			<div class="action-group">
 				<button type="submit">Vraag stellen</button>
-				<button id="chat-nieuw" class="secondary" type="button" disabled>Nieuw gesprek starten</button>
+				<button id="chat-nieuw" class="secondary" type="button" aria-disabled="true">Nieuw gesprek starten</button>
 			</div>
 		</form>
 

--- a/style/style.css
+++ b/style/style.css
@@ -1828,7 +1828,7 @@ th[aria-sort="descending"] .berichtenbox-sort::after {
 	flex-direction: column;
 	gap: var(--toepassing-space-padding-md);
 	inline-size: 100%;
-	min-block-size: 28em;
+	min-block-size: 24em;
 	overflow-y: auto;
 	padding: var(--toepassing-space-padding-xs);
 }


### PR DESCRIPTION
## Wat

De wait-indicator verschijnt nu vóór elk moment waarop de assistent iets nieuws toont, niet alleen tijdens de onboarding:

- volgende page-loads, vóór "Stel uw vraag, of probeer bijvoorbeeld:"
- "Nieuw gesprek starten"
- wisselen van LLM, transport of persona met een leeg gesprek (een bestaand gesprek komt meteen terug, want de assistent zegt dan niets nieuws)

Gedeelde helper `naWachten()` regelt de timing; een token breekt een vorige wachtbeurt af bij snel wisselen. Op page-load wacht die op twee frames, zodat de wachttijd niet wegvalt in de opbouw van de pagina. De wachttijd bij page-load staat nu op 1600 ms — dat wordt later nog bekeken.

## Nieuw gesprek starten

- `disabled` → `aria-disabled`, conform ontwerp-principe 2 (bereikbaar voor hulptechnologie)
- uitgeschakeld tijdens het streamen van een antwoord, anders wist een klik de chat onder het lopende antwoord vandaan
- ingeschakeld zodra er een gesprek is, ook bij een uit sessionStorage teruggezet gesprek
- volgt per combinatie de historie bij wisselen

## Getest

`node --check` schoon; handmatig gecontroleerd in de lokale dev-omgeving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)